### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Collections
+version=0.0.0
+author=Arsène von Wyss
+maintainer=Arsène von Wyss
+sentence=Fixed-Size Collections for Arduino.
+paragraph=Efficient implementations of some collection data structures.
+category=Data Processing
+url=https://github.com/avonwyss/Collections
+architectures=*


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the `src` subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata